### PR TITLE
Modify segmentation model log logic and add data analysis script

### DIFF
--- a/Segmentation/fcn/fcn.py
+++ b/Segmentation/fcn/fcn.py
@@ -58,27 +58,65 @@ def voc_colormap_to_label(mask):
 # Function to train the model.
 def train(model,
           train_loader,
-          criterion, 
-          optimizer, 
+          criterion,
+          optimizer,
           device,
           epoch,
           args):
     model.train()
-    losses = []
-    for images, targets in tqdm(train_loader):
+
+    # 初始化记录变量
+    batch_losses = []
+    batch_times = []
+    epoch_loss_sum = 0.0
+    epoch_start_time = time.time()
+
+    # 使用 tqdm 包装 DataLoader
+    pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{args.train_epochs}")
+
+    for batch_idx, (images, targets) in enumerate(pbar):
+        batch_start_time = time.time()
+
+        # 数据移至设备
         images = images.to(device)
         targets = targets.squeeze(1).long().to(device)
+
+        # 前向传播 + 计算损失
         optimizer.zero_grad()
         outputs = model(images)['out']
         loss = criterion(outputs, targets)
+
+        # 反向传播 + 优化
         loss.backward()
         optimizer.step()
-        losses.append(loss.item())
-    print(f"[INFO] Train [{epoch+1}/{args.train_epochs}] Loss: {sum(losses) / len(losses)}")
+
+        # 记录 batch 数据
+        batch_time = time.time() - batch_start_time
+        batch_loss = loss.item()
+
+        batch_losses.append(batch_loss)
+        batch_times.append(batch_time)
+        epoch_loss_sum += batch_loss
+
+        # 更新 tqdm 信息（显示当前 batch 的 loss 和 it/s）
+        pbar.set_postfix({
+            "batch_loss": f"{batch_loss:.4f}"
+        })
+
+    # 计算 epoch 级数据
+    epoch_time = time.time() - epoch_start_time
+    epoch_avg_loss = epoch_loss_sum / len(train_loader)
+    epoch_avg_it_s = len(train_loader) / epoch_time  # epoch 平均 it/s
+
+    print(f"\nEpoch {epoch+1}/{args.train_epochs} | "
+          f"Avg Loss: {epoch_avg_loss:.4f} | "
+          f"Avg it/s: {epoch_avg_it_s:.2f} | "
+          f"Time: {epoch_time:.2f}s")
+
+    # 保存模型（按需）
     if (epoch + 1) % args.saving_interval == 0:
         print("Saving model")
         torch.save(model.state_dict(), Path(args.saved_dir) / f"fcn_b{args.train_batch_size}_ep{epoch}.pt")
-    return  
 
 # Function to evaluate the model.
 def evaluate(model,

--- a/Segmentation/lraspp/train.py
+++ b/Segmentation/lraspp/train.py
@@ -79,9 +79,6 @@ def train(model,
             inputs = inputs.to(device)
             targets = targets.squeeze(1).long().to(device)
             
-            if inputs.shape[0] < 2:  # 跳过过小的batch
-                continue
-
             # 前向传播
             optimizer.zero_grad()
             outputs = model(inputs)['out']
@@ -173,7 +170,7 @@ def main():
         transform=transform,
         target_transform=target_transform,
     )
-    datasetloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    datasetloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
     
     model = lraspp_mobilenet_v3_large(weights=None, num_classes=classes)
     model.to(device)

--- a/Segmentation/lraspp/train.py
+++ b/Segmentation/lraspp/train.py
@@ -7,6 +7,8 @@ from torch import nn
 from torchvision import transforms, datasets
 import argparse
 from torchvision.models.segmentation import lraspp_mobilenet_v3_large
+from tqdm.auto import tqdm
+import time
 
 # Define the color map for VOC dataset
 VOC_COLORMAP = [
@@ -46,36 +48,81 @@ def voc_colormap_to_label(mask):
 
 
 def train(model,
-        epochs,
+          epochs,
           batch_size,
           datasetloader,
           device,
           optimizer,
           saving_interval,
           model_path):
-    criterion = nn.CrossEntropyLoss()
+
     model_dir = model_path.parent
+    model_dir.mkdir(parents=True, exist_ok=True)
+    criterion = nn.CrossEntropyLoss()
+
     for epoch in range(epochs):
-        print(f"Epoch {epoch}")
-        losses = []
-        for i, batch in enumerate(datasetloader):
-            input, target = batch
-            input = input.to(device)
-            target = target.squeeze(1).long().to(device)
-            if input.shape[0] < 2:
+        model.train()
+        epoch_loss_sum = 0.0
+        sample_cnt = 0
+        epoch_start_time = time.time()
+        batch_losses = []
+        batch_it_s = []
+
+        # 使用tqdm显示实时训练信息
+        pbar = tqdm(datasetloader, 
+                   desc=f"Epoch {epoch+1}/{epochs}")
+
+        for step, (inputs, targets) in enumerate(pbar, start=1):
+            batch_start_time = time.time()
+            
+            # 数据移至设备
+            inputs = inputs.to(device)
+            targets = targets.squeeze(1).long().to(device)
+            
+            if inputs.shape[0] < 2:  # 跳过过小的batch
                 continue
+
+            # 前向传播
             optimizer.zero_grad()
-            output = model(input)['out']
-            loss = criterion(output, target)
+            outputs = model(inputs)['out']
+            loss = criterion(outputs, targets)
+            
+            # 反向传播
             loss.backward()
             optimizer.step()
-            losses.append(loss.item())
-        print(sum(losses) /len(losses))
+
+            # 计算当前batch指标
+            batch_time = time.time() - batch_start_time
+            current_it_s = 1 / batch_time if batch_time > 0 else 0
+            current_loss = loss.item()
+
+            # 记录batch数据
+            batch_losses.append(current_loss)
+            batch_it_s.append(current_it_s)
+            epoch_loss_sum += current_loss * inputs.size(0)
+            sample_cnt += inputs.size(0)
+
+            # 更新进度条信息
+            pbar.set_postfix({
+                "batch_loss": f"{current_loss:.4f}"
+            })
+
+        # 计算epoch级指标
+        epoch_time = time.time() - epoch_start_time
+        epoch_avg_loss = epoch_loss_sum / sample_cnt
+        epoch_avg_it_s = len(datasetloader) / epoch_time if epoch_time > 0 else 0
+
+        # 打印epoch总结
+        print(f"\nEpoch {epoch+1:3d}/{epochs} | "
+              f"Avg Loss: {epoch_avg_loss:.4f} | "
+              f"Avg it/s: {epoch_avg_it_s:.2f} | "
+              f"Time: {epoch_time:.2f}s")
+
+        # 保存检查点
         if (epoch + 1) % saving_interval == 0:
-            print("Saving model")
-            torch.save(model.state_dict(), model_dir / f"lraspp_b{batch_size}_ep{epoch}.pt")
-    torch.save(model.state_dict(), model_path)
-    return
+            ckpt_path = model_dir / f"model_ep{epoch+1}.pt"
+            torch.save(model.state_dict(), ckpt_path)
+            print(f"Checkpoint saved to {ckpt_path}")
 
 def main():
     parser = argparse.ArgumentParser()

--- a/Segmentation/run_all_train.sh
+++ b/Segmentation/run_all_train.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# 定义要处理的文件夹列表
+folders=("deeplab" "fcn" "lraspp" "unet")
+
+# 遍历每个文件夹
+for folder in "${folders[@]}"; do
+    # 检查文件夹是否存在
+    if [ -d "$folder" ]; then
+        echo "进入文件夹: $folder"
+        cd "$folder" || exit 1  # 如果进入失败则退出
+
+        # 检查 run_train.sh 是否存在
+        if [ -f "run_train.sh" ]; then
+            echo "正在运行 run_train.sh，日志输出到 ${folder}_train.log"
+            # 运行脚本并重定向输出到日志文件
+            bash ./run_train.sh > "../${folder}_train.log" 2>&1
+            echo "完成 $folder 的训练"
+        else
+            echo "错误：$folder 中没有找到 run_train.sh"
+        fi
+
+        # 返回上级目录
+        cd ..
+    else
+        echo "错误：文件夹 $folder 不存在"
+    fi
+done
+
+echo "所有训练任务已完成"

--- a/Segmentation/segmentation_analysis.py
+++ b/Segmentation/segmentation_analysis.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import re
+import os
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+
+def parse_logs(log_paths, plot=False):
+    # 正则表达式
+    batch_re = re.compile(r'(?P<speed>[\d\.]+)it/s(?:, batch_loss=(?P<loss>[\d\.]+))?')
+    epoch_info_re = re.compile(r'\[INFO\] Train \[(?P<epoch>\d+)/\d+\] Loss: (?P<loss>[\d\.]+)')
+    epoch_sum_re = re.compile(r'Epoch\s*(?P<epoch>\d+)/\d+\s*\|\s*Avg Loss:\s*(?P<loss>[\d\.]+)\s*\|\s*Avg it/s:\s*(?P<speed>[\d\.]+)')
+
+    all_data = {}
+
+    for path in log_paths:
+        model_name = os.path.splitext(os.path.basename(path))[0]
+        batch_records = []
+        epoch_records = []
+        current_epoch = None
+        batch_speeds = []
+
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                # epoch 切换
+                m_epoch_start = re.search(r'(?:Training epoch|Epoch)\s*(\d+)/\d+', line)
+                if m_epoch_start:
+                    current_epoch = int(m_epoch_start.group(1))
+                    batch_speeds.clear()
+
+                # batch-level
+                m_batch = batch_re.search(line)
+                if m_batch and current_epoch is not None:
+                    speed = float(m_batch.group('speed'))
+                    loss = m_batch.group('loss')
+                    loss = float(loss) if loss is not None else pd.NA
+                    batch_records.append({
+                        'epoch': current_epoch,
+                        'global_batch_idx': len(batch_records),
+                        'loss': loss,
+                        'it/s': speed
+                    })
+                    batch_speeds.append(speed)
+                    continue
+
+                # epoch summary 优先匹配 Avg Loss 行
+                m_sum = epoch_sum_re.search(line)
+                if m_sum:
+                    epoch = int(m_sum.group('epoch'))
+                    loss = float(m_sum.group('loss'))
+                    speed = float(m_sum.group('speed'))
+                    epoch_records.append({'epoch': epoch, 'loss': loss, 'it/s': speed})
+                    continue
+
+                # 兼容 Deeplab 的 INFO 行
+                m_info = epoch_info_re.search(line)
+                if m_info:
+                    epoch = int(m_info.group('epoch'))
+                    loss = float(m_info.group('loss'))
+                    speed = (sum(batch_speeds)/len(batch_speeds)) if batch_speeds else pd.NA
+                    epoch_records.append({'epoch': epoch, 'loss': loss, 'it/s': speed})
+
+        df_batch = pd.DataFrame(batch_records)
+        df_epoch = pd.DataFrame(epoch_records)
+
+        # 写入 CSV
+        df_batch.to_csv(f"{model_name}_batch_metrics.csv", index=False)
+        df_epoch.to_csv(f"{model_name}_epoch_metrics.csv", index=False)
+
+        all_data[model_name] = (df_batch, df_epoch)
+
+    if plot:
+        for model, (df_batch, df_epoch) in all_data.items():
+            fig, axs = plt.subplots(2, 2, figsize=(12, 8))
+            fig.suptitle(f"Metrics for {model}", fontsize=16)
+
+            # Batch Loss
+            if not df_batch['loss'].dropna().empty:
+                df_batch['loss'].plot(ax=axs[0,0], title="Batch Loss")
+                axs[0,0].set_xlabel("Global Batch Index")
+                axs[0,0].set_ylabel("Loss")
+            else:
+                axs[0,0].text(0.5, 0.5, "No batch loss data", ha='center', va='center')
+                axs[0,0].set_title("Batch Loss"); axs[0,0].axis('off')
+
+            # Batch it/s
+            if not df_batch['it/s'].empty:
+                df_batch['it/s'].plot(ax=axs[0,1], title="Batch it/s")
+                axs[0,1].set_xlabel("Global Batch Index")
+                axs[0,1].set_ylabel("it/s")
+            else:
+                axs[0,1].text(0.5, 0.5, "No batch speed data", ha='center', va='center')
+                axs[0,1].set_title("Batch it/s"); axs[0,1].axis('off')
+
+            # Epoch Loss
+            if not df_epoch['loss'].empty:
+                df_epoch.plot(x='epoch', y='loss', marker='o', ax=axs[1,0], title="Epoch Loss")
+                axs[1,0].set_xlabel("Epoch"); axs[1,0].set_ylabel("Loss")
+            else:
+                axs[1,0].text(0.5, 0.5, "No epoch loss data", ha='center', va='center')
+                axs[1,0].set_title("Epoch Loss"); axs[1,0].axis('off')
+
+            # Epoch it/s
+            if not df_epoch['it/s'].empty:
+                df_epoch.plot(x='epoch', y='it/s', marker='o', ax=axs[1,1], title="Epoch it/s")
+                axs[1,1].set_xlabel("Epoch"); axs[1,1].set_ylabel("it/s")
+            else:
+                axs[1,1].text(0.5, 0.5, "No epoch speed data", ha='center', va='center')
+                axs[1,1].set_title("Epoch it/s"); axs[1,1].axis('off')
+
+            plt.tight_layout(rect=[0,0.03,1,0.95])
+        plt.show()
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse training logs and extract metrics")
+    parser.add_argument("logs", nargs="+", help="路径到训练日志文件")
+    parser.add_argument("--plot", action="store_true", help="是否绘制图表")
+    args = parser.parse_args()
+
+    parse_logs(args.logs, plot=args.plot)
+
+if __name__ == "__main__":
+    main()
+

--- a/Segmentation/unet/train.py
+++ b/Segmentation/unet/train.py
@@ -81,9 +81,6 @@ def train(model,
             inputs = inputs.to(device)
             targets = targets.to(device, dtype=torch.long).squeeze()
             
-            if inputs.size(0) < 2:  # 跳过过小的batch
-                continue
-
             # 前向传播
             optimizer.zero_grad()
             outputs = model(inputs)
@@ -179,7 +176,7 @@ def main():
         transform=transform,
         target_transform=target_transform
     )
-    datasetloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    datasetloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
 
     model = UNet(classes)
     model.to(device)


### PR DESCRIPTION
# Description
Modify segmentation model log logic and add data analysis script

# Test evidence
1. run `bash run_train_all.sh > train.log 2>&1`
2. We could get `xx_train.log` file, file content is listed here:
```
../data/VOCdevkit exists
/home/libaoming/baoming_env/lib/python3.10/site-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
/home/libaoming/baoming_env/lib/python3.10/site-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=None`.
  warnings.warn(msg)
{'train_batch_size': 4, 'train_epochs': 10, 'infer_batch_size': 1, 'device': device(type='cuda'), 'image_size': 256, 'dataset_root': '/home/libaoming/workplace/PyTorchModels/Segmentation/data', 'mode': 'train', 'num_classes': 21, 'saved_dir': 'model', 'saving_interval': 5}
[INFO] Start training on cuda.
[INFO] Training epoch 1/10.

Epoch 1/10:   0%|          | 0/52 [00:00<?, ?it/s]
Epoch 1/10:   0%|          | 0/52 [00:03<?, ?it/s, batch_loss=3.2994]
Epoch 1/10:   2%|▏         | 1/52 [00:03<03:03,  3.59s/it, batch_loss=3.2994]
Epoch 1/10:   2%|▏         | 1/52 [00:03<03:03,  3.59s/it, batch_loss=3.1488]
Epoch 1/10:   2%|▏         | 1/52 [00:03<03:03,  3.59s/it, batch_loss=3.2247]
Epoch 1/10:   2%|▏         | 1/52 [00:03<03:03,  3.59s/it, batch_loss=3.1155]
```
3. Then we use `segmentation_analysis.py` to get analysis data in Win.
```
python .\segmentation_analysis.py .\fcn_train.log --plot 
```
4. We could get data file and data figure.
![fcn_data](https://github.com/user-attachments/assets/2d5b4494-68fc-44a4-9a32-9b6ca8939155)

